### PR TITLE
Docs: README에 secret_keys 템플릿 위치 변경 내용 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 1.Project/config/secret_keys.xml.template 파일을 확인
 
-2.해당 파일을 복사하여 같은 위치에 secret_keys.xml로 저장
+2.해당 파일을 복사하여 app/src/main/res/values/secret_keys.xml로 저장
 
 3.템플릿의 [YOUR_CLIENT_ID] 등 placeholder를 실제 발급받은 키 값으로 변경
 


### PR DESCRIPTION
빌드 오류를 방지하기 위해 템플릿 파일 위치를 res 폴더 밖으로 이동한 내용을 README에 반영함. 팀원들이 새로운 경로(config/secret_keys.xml.template)를 참고하도록 가이드 문구를 수정함.