### PR TITLE
Design: 툴바 사용자 이름 TextView 길이 제한 및 말줄임표 처리

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,52 +7,74 @@
     android:src="@drawable/logotwo">
 
     <!--툴바-->
-    <androidx.appcompat.widget.LinearLayoutCompat
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/topToolBar"
         android:layout_width="match_parent"
         android:layout_height="110dp"
-        android:orientation="horizontal"
-        android:paddingTop="60dp"
+        android:paddingTop="45dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toTopOf="@id/mainContainer"
         android:background="@color/mainColor">
 
+        <!-- 프로필 이미지 -->
         <ImageView
             android:id="@+id/toolbarCareTargetImage"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
             android:layout_marginStart="10dp"
-            android:layout_marginEnd="10dp"
             android:background="@drawable/ic_myinfo_selected"
-            android:contentDescription="@string/stringToolbarCareTargetImage"/>
+            android:contentDescription="@string/stringToolbarCareTargetImage"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+        <!-- 사용자 이름 -->
         <TextView
             android:id="@+id/toolbarCareTargetNameText"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="5dp"
-            android:text="adsf"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
             android:textSize="17sp"
-            android:textColor="@color/black"/>
+            android:textColor="@color/black"
+            android:maxLines="1"
+            android:ellipsize="end"
+            android:maxWidth="100dp"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintStart_toEndOf="@id/toolbarCareTargetImage"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+        <!-- 프래그먼트 이름 -->
         <TextView
             android:id="@+id/toolbarFragmentName"
-            android:layout_width="60dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:gravity="center"
-            android:layout_marginStart="85dp"
-            android:layout_marginEnd="125dp"
             android:text="@string/stringHome"
-            android:textColor="@color/black"
             android:textSize="18sp"
-            android:textStyle="bold"/>
+            android:textStyle="bold"
+            android:textColor="@color/black"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.51"/>
+
+        <!-- 알림 버튼 -->
         <ImageButton
             android:id="@+id/toolbarAlarmImageButton"
             android:layout_width="30dp"
             android:layout_height="30dp"
+            android:layout_marginEnd="10dp"
             android:background="@drawable/warning"
             android:scaleType="centerInside"
-            android:contentDescription="@string/stringToolbarAlarmImageButton"/>
-    </androidx.appcompat.widget.LinearLayoutCompat>
+            android:contentDescription="@string/stringToolbarAlarmImageButton"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <!--메인 화면-->
     <FrameLayout


### PR DESCRIPTION
툴바 내 사용자 이름이 너무 길 경우 레이아웃이 깨지는 문제를 방지하기 위해
`toolbarCareTargetNameText`에 maxWidth와 ellipsize 속성 추가함. 이로 인해 툴바 중앙 정렬된 프래그먼트 이름과 알림 버튼이 밀리지 않도록 UI 개선.