### PR TITLE
Feat: 상단바에 현재 화면 이름 표시 기능 추가

### DIFF
--- a/app/src/main/java/com/example/pillcare_capstone/MainActivity.kt
+++ b/app/src/main/java/com/example/pillcare_capstone/MainActivity.kt
@@ -131,10 +131,24 @@ class MainActivity : AppCompatActivity() {
     private fun updateToolbarView(fragment: Fragment) {
         when (fragment) {
             is HomeFragment -> {
+                viewBinding.toolbarFragmentName.text = "홈"
                 viewBinding.toolbarCareTargetImage.visibility = View.VISIBLE
                 viewBinding.toolbarCareTargetNameText.visibility = View.VISIBLE
             }
+            is MyInfoFragment -> {
+                viewBinding.toolbarFragmentName.text = "내 정보"
+                viewBinding.toolbarFragmentName.visibility = View.VISIBLE
+                viewBinding.toolbarCareTargetImage.visibility = View.INVISIBLE
+                viewBinding.toolbarCareTargetNameText.visibility = View.INVISIBLE
+            }
+            is SettingFragment -> {
+                viewBinding.toolbarFragmentName.text = "설정"
+                viewBinding.toolbarFragmentName.visibility = View.VISIBLE
+                viewBinding.toolbarCareTargetImage.visibility = View.INVISIBLE
+                viewBinding.toolbarCareTargetNameText.visibility = View.INVISIBLE
+            }
             else -> {
+                viewBinding.toolbarFragmentName.visibility = View.GONE
                 viewBinding.toolbarCareTargetImage.visibility = View.INVISIBLE
                 viewBinding.toolbarCareTargetNameText.visibility = View.INVISIBLE
             }


### PR DESCRIPTION
하단 탭(홈, 내 정보, 설정)을 전환할 때마다 상단바의 제목이 현재 화면 이름으로 동적으로 변경되도록 구현함. 이를 통해 사용자가 현재 어떤 화면에 있는지 명확하게 인지할 수 있도록 UX를 개선함